### PR TITLE
add TAGGED_UNION_CASE macro to avoid runtime error possibility

### DIFF
--- a/include/TaggedUnion.h
+++ b/include/TaggedUnion.h
@@ -117,3 +117,9 @@ private:
     }\
   };
 
+
+#define _tagged_union_join2(a, b) a ## b
+#define _tagged_union_join(a, b) _tagged_union_join2(a, b)
+
+#define TAGGED_UNION_CASE(_CaseType, _CaseVariant, _obj, _typed) \
+    _CaseType::Kind::_CaseVariant: auto &_typed = _obj.as<_CaseVariant>(); _tagged_union_join(_dummy_label, __LINE__)

--- a/main.cpp
+++ b/main.cpp
@@ -64,6 +64,27 @@ void examplePrintEventKind(MouseEvent const &event) {
   }
 }
 
+void examplePrintEventKindWithMacro(MouseEvent const &event) {
+  // This example uses the TAGGED_UNION_CASE macro to couple the case value with
+  // the resulting type of the tagged-union value.  This removes the possibility
+  // of a runtime error where the 2 are mismatched.
+  switch (event.kind()) {
+    {
+      case TAGGED_UNION_CASE(MouseEvent, RelativeMove, event, relative_move):
+      printf("move %d x %d\n", relative_move.delta_x, relative_move.delta_y);
+      break;
+    }{
+      case TAGGED_UNION_CASE(MouseEvent, Button, event, button):
+      printf("button code=%d down=%d\n", button.code, button.down);
+      break;
+    }{
+      case TAGGED_UNION_CASE(MouseEvent, Scroll, event, scroll):
+      printf("scroll %d x %d\n", scroll.delta_x, scroll.delta_y);
+      break;
+    }
+  }
+}
+
 int main() {
   examplePrintEventIndexed(MouseEvent::create<RelativeMove>(1, 0));
   examplePrintEventIndexed(MouseEvent::create<Button>(uint16_t(123), true));
@@ -74,6 +95,9 @@ int main() {
   examplePrintEventKind(RelativeMove{1, 0});
   examplePrintEventKind(Button{uint16_t(123), true});
   examplePrintEventKind(Scroll{-2, 3});
+  examplePrintEventKindWithMacro(RelativeMove{1, 0});
+  examplePrintEventKindWithMacro(Button{uint16_t(123), true});
+  examplePrintEventKindWithMacro(Scroll{-2, 3});
   try {
     MouseEvent::create<Scroll>(-2, 3).as<Button>();
   } catch (char const *e) {


### PR DESCRIPTION
Currently, using switch to exhaustively cover all cases of a tagged union has the potential for the following runtime bug:

```cpp
case MouseEvent::Kind::RelativeMove: {
    auto &e = event.as<Button>();
    // code that uses e
    break;
}
```

This potential runtime error can be removed by adding a macro that couples the case expression with the type passed to "as".  The previous code becomes:

```cpp
{
    case TAGGED_UNION_CASE(MouseEvent, RelativeMove, event, e):
    // code that uses 'e', properly typed as RelativeMove
    break;
}
```

I played around with a few different ways of defining TAGGED_UNION_CASE. I tried a version where it introduced a new scope before defining the typed variable, however, this required either placing a dangling close brace `}` or defining a second TAGGED_UNION_CASE_END macro to end the newly created scope.  Instead I realized you could create a scope around the whole case which removed the need for the macro to create its own scope.  I was able to allow the user to maintain the syntax `case EXPR:`.  The tricky part was allowing the trailing `:` to end the case statement.  I solved this by ending TAGGED_UNION_CASE with a dummy "code label" that would be delimited by the user's `:` character.